### PR TITLE
Do not create a new loop, use the default one.

### DIFF
--- a/hypercorn/run.py
+++ b/hypercorn/run.py
@@ -117,8 +117,7 @@ def run_single(
             asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     if loop is None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        loop = asyncio.get_event_loop()
 
     loop.set_debug(config.debug)
 


### PR DESCRIPTION
Normally, components are expected to use the default loop
unless explicitly provided one (also quart used to have such
contract). Current behaviour of Hypercorn breaks it and
makes initializing them trickier ootb.