### PR TITLE
Fix trio with multiple workers

### DIFF
--- a/src/hypercorn/trio/run.py
+++ b/src/hypercorn/trio/run.py
@@ -106,6 +106,6 @@ def trio_worker(
 
     shutdown_trigger = None
     if shutdown_event is not None:
-        shutdown_trigger = check_multiprocess_shutdown_event(shutdown_event, trio.sleep)
+        shutdown_trigger = partial(check_multiprocess_shutdown_event, shutdown_event, trio.sleep)
 
     trio.run(partial(worker_serve, app, config, sockets=sockets, shutdown_trigger=shutdown_trigger))


### PR DESCRIPTION
The `shutdown_trigger` argument of `worker_serve` needs to be a callable returning an awaitable, not an awaitable directly.

Without this, I get:

```
  File "/Users/michael/Library/Caches/pypoetry/virtualenvs/dbserver-k0bMYWkt-py3.7/lib/python3.7/site-packages/trio/_core/_run.py", line 730, in __aexit__
    raise combined_error_from_nursery
  File "/Users/michael/Library/Caches/pypoetry/virtualenvs/dbserver-k0bMYWkt-py3.7/lib/python3.7/site-packages/trio/_core/_run.py", line 730, in __aexit__
    raise combined_error_from_nursery
  File "/Users/michael/Library/Caches/pypoetry/virtualenvs/dbserver-k0bMYWkt-py3.7/lib/python3.7/site-packages/hypercorn/utils.py", line 156, in raise_shutdown
    await shutdown_event()
  File "/Users/michael/Library/Caches/pypoetry/virtualenvs/dbserver-k0bMYWkt-py3.7/lib/python3.7/site-packages/hypercorn/utils.py", line 156, in raise_shutdown
    await shutdown_event()
```

Whenever multiple workers are used.