### PR TITLE
Don't Require 'typing_extensions' in Python 3.8+

### DIFF
--- a/src/hypercorn/typing.py
+++ b/src/hypercorn/typing.py
@@ -3,7 +3,12 @@ from typing import Any, Awaitable, Callable, Optional, Tuple, Type, Union
 
 import h2.events
 import h11
-from typing_extensions import Protocol  # Till PEP 544 is accepted
+
+# Till PEP 544 is accepted
+try:
+    from typing import Protocol
+except:
+    from typing_extensions import Protocol  
 
 from .config import Config, Sockets
 


### PR DESCRIPTION
According to the documentation only Python version 3.7 and above are supported by Hypercorn. Python 3.8 has been out for quite a while and 3.9 is soon to be released. There is no need to maintain the dependency on the 'typing_extensions' package for folks using 3.8 and higher.