### PR TITLE
python: prefix is deprecated

### DIFF
--- a/src/hypercorn/__main__.py
+++ b/src/hypercorn/__main__.py
@@ -13,8 +13,8 @@ sentinel = object()
 def _load_config(config_path: Optional[str]) -> Config:
     if config_path is None:
         return Config()
-    elif config_path.startswith("python:"):
-        return Config.from_pyfile(config_path[len("python:") :])
+    elif config_path.endswith(".py"):
+        return Config.from_pyfile(config_path)
     else:
         return Config.from_toml(config_path)
 


### PR DESCRIPTION
I found "python:" prefix unnecessary so i propose to use ".py" suffix to identify python config files.