### PR TITLE
Python 3.10 compatibility update

### DIFF
--- a/src/hypercorn/asyncio/run.py
+++ b/src/hypercorn/asyncio/run.py
@@ -108,7 +108,6 @@ async def worker_serve(
             await asyncio.start_server(
                 _server_callback,
                 backlog=config.backlog,
-                loop=loop,
                 ssl=ssl_context,
                 sock=sock,
                 ssl_handshake_timeout=ssl_handshake_timeout,


### PR DESCRIPTION
Removed loop argument in asyncio.start_server(), which is totally deprecated in Python 3.10