### PR TITLE
Attempted fix at WinError 10022

### DIFF
--- a/src/hypercorn/run.py
+++ b/src/hypercorn/run.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import platform
-import random
 import signal
 import time
 from multiprocessing import Event, Process
@@ -62,7 +61,7 @@ def run_multiple(config: Config, worker_func: WorkerFunc) -> None:
         process.start()
         processes.append(process)
         if platform.system() == "Windows":
-            time.sleep(0.1 * random.random())
+            time.sleep(0.1)
 
     def shutdown(*args: Any) -> None:
         shutdown_event.set()


### PR DESCRIPTION
By ensuring at least 0.1 seconds of delay between each worker start, that _should theoretically_ remove the chance of workers failing to start on Windows.

My theory is that there is a small chance of `WinError 10022` when socket connections are formed back-to back. Since the previous implementation used `0.1 * math.random()`, there was a small chance of the sleep value being close zero or close to zero.

Which would make sense, my rate of occurrence felt like roughly 1%.