### PR TITLE
Fix handling of TCP EOF

### DIFF
--- a/src/hypercorn/asyncio/tcp_server.py
+++ b/src/hypercorn/asyncio/tcp_server.py
@@ -101,10 +101,11 @@ class TCPServer:
                 TimeoutError,
                 SSLError,
             ):
-                await self.protocol.handle(Closed())
                 break
-            else:
+
+            if data:
                 await self.protocol.handle(RawData(data))
+        await self.protocol.handle(Closed())
 
     async def _close(self) -> None:
         try:

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -97,12 +97,12 @@ class TCPServer:
                 with trio.fail_after(self.config.read_timeout or inf):
                     data = await self.stream.receive_some(MAX_RECV)
             except (trio.ClosedResourceError, trio.BrokenResourceError):
-                await self.protocol.handle(Closed())
                 break
             else:
                 await self.protocol.handle(RawData(data))
                 if data == b"":
                     break
+        await self.protocol.handle(Closed())
 
     async def _close(self) -> None:
         try:

--- a/tests/asyncio/test_tcp_server.py
+++ b/tests/asyncio/test_tcp_server.py
@@ -40,11 +40,12 @@ async def test_complets_on_half_close(event_loop: asyncio.AbstractEventLoop) -> 
     )
     task = event_loop.create_task(server.run())
     await server.reader.send(b"GET / HTTP/1.1\r\nHost: hypercorn\r\n\r\n")  # type: ignore
+    await asyncio.sleep(0.001)
     server.reader.close()  # type: ignore
-    await asyncio.sleep(0)
+    await task
+
     data = await server.writer.receive()  # type: ignore
     assert (
         data
         == b"HTTP/1.1 200 \r\ncontent-length: 335\r\ndate: Thu, 01 Jan 1970 01:23:20 GMT\r\nserver: hypercorn-h11\r\n\r\n"  # noqa: E501
     )
-    await task


### PR DESCRIPTION
This patch fixes handling of StreamReader.read for the case when remote client terminates the connection. As documented here: https://docs.python.org/3.4/library/asyncio-stream.html#asyncio.StreamReader.read read method retuns `b""` in this case.