### PR TITLE
Use tomllib/tomli for .toml support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ h11 = "*"
 h2 = ">=3.1.0"
 priority = "*"
 pydata_sphinx_theme = { version = "*", optional = true }
-toml = "*"
+tomli = { version = "*", python = "<3.11" }
 trio = { version = ">=0.11.0", optional = true }
 typing_extensions = { version = ">=3.7.4", python = "<3.8" }
 uvloop = { version = "*", markers = "platform_system != 'Windows'", optional = true }

--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -6,6 +6,7 @@ import logging
 import os
 import socket
 import stat
+import sys
 import types
 import warnings
 from dataclasses import dataclass
@@ -22,7 +23,10 @@ from time import time
 from typing import Any, AnyStr, Dict, List, Mapping, Optional, Tuple, Type, Union
 from wsgiref.handlers import format_date_time
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from .logging import Logger
 
@@ -355,8 +359,8 @@ class Config:
             filename: The filename which gives the path to the file.
         """
         file_path = os.fspath(filename)
-        with open(file_path) as file_:
-            data = toml.load(file_)
+        with open(file_path, "rb") as file_:
+            data = tomllib.load(file_)
         return cls.from_mapping(data)
 
     @classmethod

--- a/src/hypercorn/logging.py
+++ b/src/hypercorn/logging.py
@@ -9,7 +9,11 @@ from http import HTTPStatus
 from logging.config import dictConfig, fileConfig
 from typing import Any, IO, Mapping, Optional, TYPE_CHECKING, Union
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 
 if TYPE_CHECKING:
     from .config import Config
@@ -65,8 +69,8 @@ class Logger:
                 with open(config.logconfig[5:]) as file_:
                     dictConfig(json.load(file_))
             elif config.logconfig.startswith("toml:"):
-                with open(config.logconfig[5:]) as file_:
-                    dictConfig(toml.load(file_))
+                with open(config.logconfig[5:], "rb") as file_:
+                    dictConfig(tomllib.load(file_))
             else:
                 log_config = {
                     "__file__": config.logconfig,

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ basepython = python3.10
 deps =
     mypy
     pytest
-    types-toml
 commands =
     mypy src/hypercorn/ tests/
 


### PR DESCRIPTION
Replace the unmaintained and non-conformant `toml` library with the built-in `tomllib` module in Python 3.11+, with fallback to `tomli` (featuring the same ABI) in Python 3.10 and older.