### PR TITLE
bug(lifespan): server hangs on startup failure

### DIFF
--- a/src/hypercorn/asyncio/lifespan.py
+++ b/src/hypercorn/asyncio/lifespan.py
@@ -98,9 +98,9 @@ class Lifespan:
             self.shutdown.set()
         elif message["type"] == "lifespan.startup.failed":
             self.startup.set()
-            raise LifespanFailureError("startup", message["message"])
+            raise LifespanFailureError("startup", message.get("message", ""))
         elif message["type"] == "lifespan.shutdown.failed":
             self.shutdown.set()
-            raise LifespanFailureError("shutdown", message["message"])
+            raise LifespanFailureError("shutdown", message.get("message", ""))
         else:
             raise UnexpectedMessageError(message["type"])

--- a/src/hypercorn/trio/lifespan.py
+++ b/src/hypercorn/trio/lifespan.py
@@ -90,8 +90,8 @@ class Lifespan:
         elif message["type"] == "lifespan.shutdown.complete":
             self.shutdown.set()
         elif message["type"] == "lifespan.startup.failed":
-            raise LifespanFailureError("startup", message["message"])
+            raise LifespanFailureError("startup", message.get("message", ""))
         elif message["type"] == "lifespan.shutdown.failed":
-            raise LifespanFailureError("shutdown", message["message"])
+            raise LifespanFailureError("shutdown", message.get("message", ""))
         else:
             raise UnexpectedMessageError(message["type"])


### PR DESCRIPTION
`message` key is optional:
https://asgi.readthedocs.io/en/latest/specs/lifespan.html#startup-failed-send-event

Still `hypercorn` expects it, result is `KeyError` which
doesn't terminate the server.