### PR TITLE
Close websocket with 1011 on internal error (1006 is a client-only code)

### DIFF
--- a/src/hypercorn/protocol/ws_stream.py
+++ b/src/hypercorn/protocol/ws_stream.py
@@ -257,7 +257,7 @@ class WSStream:
                     self.scope, {"status": 500, "headers": []}, time() - self.start_time
                 )
             elif self.state == ASGIWebsocketState.CONNECTED:
-                await self._send_wsproto_event(CloseConnection(code=CloseReason.ABNORMAL_CLOSURE))
+                await self._send_wsproto_event(CloseConnection(code=CloseReason.INTERNAL_ERROR))
             await self.send(StreamClosed(stream_id=self.stream_id))
         else:
             if message["type"] == "websocket.accept" and self.state == ASGIWebsocketState.HANDSHAKE:


### PR DESCRIPTION
See https://www.rfc-editor.org/rfc/rfc6455.html ->
```
1006 is a reserved value and MUST NOT be set as a status code in a
      Close control frame by an endpoint.
```

This issue is exacerbated by what may be a bug in wsproto, where a 1006 code is turned into a 1000 (success) code.