### PR TITLE
feat: support python3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: '3.11-dev', python: '3.11-dev', tox: py311}
+          - {name: '3.11', python: '3.11', tox: py311}
           - {name: '3.10', python: '3.10', tox: py310}
           - {name: '3.9', python: '3.9', tox: py39}
           - {name: '3.8', python: '3.8', tox: py38}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,format,mypy,py37,py38,py39,py310,package,pep8
+envlist = docs,format,mypy,py37,py38,py39,py310,py311,package,pep8
 minversion = 3.3
 isolated_build = true
 


### PR DESCRIPTION
This PR is as much a question as a contribution:
Is hypercorn ready to "officially" support Python 3.11?

The unit tests pass according to the GitHub CI workflow as well as tox on my local system.
Is there anything else that needs to be done?