### PR TITLE
Fix defined CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
   autobahn:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    container: python:2.7.16-alpine3.10
     strategy:
       fail-fast: false
       matrix:
@@ -91,20 +90,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: apk --update add build-base libressl libressl-dev ca-certificates libffi-dev python3 python3-dev
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
 
       - name: update pip
         run: |
           pip install -U wheel
           pip install -U setuptools
           python -m pip install -U pip
-      - run: pip install pyopenssl==19.1.0 cryptography==2.3.1 Twisted==12.1 wsaccel==0.6.2 autobahntestsuite
       - run: python3 -m pip install trio .
-
       - name: Run server
         working-directory: compliance/autobahn
         run: nohup hypercorn -k ${{ matrix.worker }} server:app &
 
-      - name: Run server
+      - name: Run Unit Tests
         working-directory: compliance/autobahn
-        run: wstest -m fuzzingclient && python summarise.py
+        run: docker run --rm --network=host -v "${PWD}/:/config" -v "${PWD}/reports:/reports" --name fuzzingclient crossbario/autobahn-testsuite wstest -m fuzzingclient -s /config/fuzzingclient.json && python3 summarise.py

--- a/src/hypercorn/app_wrappers.py
+++ b/src/hypercorn/app_wrappers.py
@@ -68,8 +68,8 @@ class WSGIWrapper:
             message = await receive()
             body.extend(message.get("body", b""))  # type: ignore
             if len(body) > self.max_body_size:
-                await send({"type": "http.response.start", "status": 400, "headers": []})  # type: ignore # noqa: E501
-                await send({"type": "http.response.body", "body": b"", "more_body": False})  # type: ignore # noqa: E501
+                await send({"type": "http.response.start", "status": 400, "headers": []})
+                await send({"type": "http.response.body", "body": b"", "more_body": False})
                 return
             if not message.get("more_body"):
                 break
@@ -77,10 +77,10 @@ class WSGIWrapper:
         try:
             environ = _build_environ(scope, body)
         except InvalidPathError:
-            await send({"type": "http.response.start", "status": 404, "headers": []})  # type: ignore # noqa: E501
+            await send({"type": "http.response.start", "status": 404, "headers": []})
         else:
             await sync_spawn(self.run_app, environ, partial(call_soon, send))
-        await send({"type": "http.response.body", "body": b"", "more_body": False})  # type: ignore
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
 
     def run_app(self, environ: dict, send: Callable) -> None:
         headers: List[Tuple[bytes, bytes]]

--- a/src/hypercorn/protocol/http_stream.py
+++ b/src/hypercorn/protocol/http_stream.py
@@ -111,7 +111,7 @@ class HTTPStream:
         elif isinstance(event, StreamClosed):
             self.closed = True
             if self.app_put is not None:
-                await self.app_put({"type": "http.disconnect"})  # type: ignore
+                await self.app_put({"type": "http.disconnect"})
 
     async def app_send(self, message: Optional[ASGISendEvent]) -> None:
         if self.closed:

--- a/src/hypercorn/protocol/ws_stream.py
+++ b/src/hypercorn/protocol/ws_stream.py
@@ -231,7 +231,7 @@ class WSStream:
                 self.app_put = await self.task_group.spawn_app(
                     self.app, self.config, self.scope, self.app_send
                 )
-                await self.app_put({"type": "websocket.connect"})  # type: ignore
+                await self.app_put({"type": "websocket.connect"})
         elif isinstance(event, (Body, Data)):
             self.connection.receive_data(event.data)
             await self._handle_events()

--- a/src/hypercorn/protocol/ws_stream.py
+++ b/src/hypercorn/protocol/ws_stream.py
@@ -333,7 +333,9 @@ class WSStream:
         )
 
     async def _send_wsproto_event(self, event: WSProtoEvent) -> None:
-        data = self.connection.send(event)
+        data = b""
+        if self.connection.state != ConnectionState.CLOSED:
+            data = self.connection.send(event)
         await self.send(Data(stream_id=self.stream_id, data=data))
 
     async def _accept(self, message: WebsocketAcceptEvent) -> None:

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -83,8 +83,9 @@ class TCPServer:
                 except (trio.BrokenResourceError, trio.ClosedResourceError):
                     await self.protocol.handle(Closed())
         elif isinstance(event, Closed):
-            await self._close()
-            await self.protocol.handle(Closed())
+            async with self.send_lock:
+                await self._close()
+                await self.protocol.handle(Closed())
         elif isinstance(event, Updated):
             if event.idle:
                 await self._start_idle()

--- a/tests/asyncio/test_keep_alive.py
+++ b/tests/asyncio/test_keep_alive.py
@@ -32,13 +32,13 @@ async def slow_framework(
         elif event["type"] == "http.request" and not event.get("more_body", False):
             await asyncio.sleep(2 * KEEP_ALIVE_TIMEOUT)
             await send(
-                {  # type: ignore
+                {
                     "type": "http.response.start",
                     "status": 200,
                     "headers": [(b"content-length", b"0")],
                 }
             )
-            await send({"type": "http.response.body", "body": b"", "more_body": False})  # type: ignore # noqa: E501
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
             break
 
 

--- a/tests/asyncio/test_task_group.py
+++ b/tests/asyncio/test_task_group.py
@@ -25,7 +25,7 @@ async def test_spawn_app(event_loop: asyncio.AbstractEventLoop, http_scope: HTTP
         put = await task_group.spawn_app(
             ASGIWrapper(_echo_app), Config(), http_scope, app_queue.put
         )
-        await put({"type": "http.disconnect"})  # type: ignore
+        await put({"type": "http.disconnect"})
         assert (await app_queue.get()) == {"type": "http.disconnect"}
         await put(None)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,7 +11,6 @@ SANITY_BODY = b"Hello Hypercorn"
 
 
 class MockSocket:
-
     family = AF_INET
 
     def getsockname(self) -> Tuple[str, int]:
@@ -58,13 +57,13 @@ async def echo_framework(
                 response = dumps({"scope": scope, "request_body": body.decode()}).encode()
                 content_length = len(response)
                 await send(
-                    {  # type: ignore
+                    {
                         "type": "http.response.start",
                         "status": 200,
                         "headers": [(b"content-length", str(content_length).encode())],
                     }
                 )
-                await send({"type": "http.response.body", "body": response, "more_body": False})  # type: ignore # noqa: E501
+                await send({"type": "http.response.body", "body": response, "more_body": False})
                 break
         elif event["type"] == "websocket.connect":
             await send({"type": "websocket.accept"})  # type: ignore
@@ -78,7 +77,7 @@ async def lifespan_failure(
     while True:
         message = await receive()
         if message["type"] == "lifespan.startup":
-            await send({"type": "lifespan.startup.failed", "message": "Failure"})  # type: ignore
+            await send({"type": "lifespan.startup.failed", "message": "Failure"})
         break
 
 
@@ -105,13 +104,13 @@ async def sanity_framework(
             response = b"Hello & Goodbye"
             content_length = len(response)
             await send(
-                {  # type: ignore
+                {
                     "type": "http.response.start",
                     "status": 200,
                     "headers": [(b"content-length", str(content_length).encode())],
                 }
             )
-            await send({"type": "http.response.body", "body": response, "more_body": False})  # type: ignore # noqa: E501
+            await send({"type": "http.response.body", "body": response, "more_body": False})
             break
         elif event["type"] == "websocket.receive":
             assert event["bytes"] == SANITY_BODY


### PR DESCRIPTION
This PR aims to fix the currently failing CI-Tests by implementing the following changes:

1. Remove not required `# type: ignore` and formatting error in `helpers.MockSocket` as these were currently failing the tox-tests for mypy and format
2. Prevent passing an event to an already closed wsproto-Connection as this raised a `LocalProtocolError` protocol error crashing the application when the application was 
3. Wrap the trio `protocol_send` for a `Closed`-Event with the `send_lock`. Although this did not crash the server, when running the autobahn-testsuite on a trio server, the log contained a lot of `trio.BusyResourceError: another task is currently sending data on this SocketStream` errors which are prevented with this.

Additionally the CI-job for the autobahn-testsuite has been adjusted to use the docker container as suggested in the autobahn-testsuite repository. This has the added benefit that we do not have to care about any python 2.7 dependencies when running these Tests! 