### PR TITLE
Replace trio.MultiError.filter() with BaseExceptionGroup.split()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ documentation = "https://hypercorn.readthedocs.io"
 [tool.poetry.dependencies]
 python = ">=3.7"
 aioquic = { version = ">= 0.9.0, < 1.0", optional = true }
+exceptiongroup = { version = ">= 1.0.0rc9", python = "<3.11", optional = true }
 h11 = "*"
 h2 = ">=3.1.0"
 priority = "*"


### PR DESCRIPTION
`TaskGroup. _handle()` uses `trio.MultiError.filter()` to filter out any instances of `trio.Cancelled` from the `MultiError`. However, when using newer versions of Python and Trio, the `MultiError` may also contain nested instances of `BaseExceptionGroup`. `trio.MultiError.filter()` cannot "see into" `BaseExceptionGroup`, so if a `trio.Cancelled` is hidden in a `BaseExceptionGroup`, it won't get filtered out properly.

This PR changes `TaskGroup._handle()` to use `BaseExceptionGroup.split()`, which correctly handles arbitrary mixtures of `trio.MultiError` and `BaseExceptionGroup`.