### PR TITLE
bug(lifespan): close listening sockets before terminating processes

### DIFF
--- a/src/hypercorn/run.py
+++ b/src/hypercorn/run.py
@@ -68,16 +68,15 @@ def run(config: Config) -> None:
         else:
             active = False
 
-    for process in processes:
-        process.join()
-    for process in processes:
-        process.terminate()
-
     for sock in sockets.secure_sockets:
         sock.close()
     for sock in sockets.insecure_sockets:
         sock.close()
 
+    for process in processes:
+        process.join()
+    for process in processes:
+        process.terminate()
 
 def start_processes(
     config: Config,


### PR DESCRIPTION
Currently, for multi-worker apps with slow shutdown (e.g. `@app.on_event("shutdown")` handler) hypercorn stops workers before closing listening socket in the parent process.  This leads to new connections stalling instead of failing with connection-refused:

```
$ pkill -f server.py; sleep 1; curl -v localhost:5000/healthz  
*   Trying 127.0.0.1:5000...
* Connected to localhost (127.0.0.1) port 5000 (#0)
> GET /healthz HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.88.1
> Accept: */*
> 

... 60 second wait ...

* Recv failure: Connection reset by peer
* Closing connection 0
curl: (56) Recv failure: Connection reset by peer
```

This PR attempts to solve this issue by closing listening sockets before stopping workers.