### PR TITLE
Expose logging formatter and relevant attributes

### DIFF
--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -61,6 +61,12 @@ class Config:
     _log: Optional[Logger] = None
     _root_path: str = ""
 
+    log_formatter = logging.Formatter(fmt="%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
+                                      datefmt="[%Y-%m-%d %H:%M:%S %z]")
+    propagate_access_log = False
+    propagate_error_log = True
+    access_log_sys_default = sys.stdout
+    error_log_sys_default = sys.stderr
     access_log_format = '%(h)s %(l)s %(l)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
     accesslog: Union[logging.Logger, str, None] = None
     alpn_protocols = ["h2", "http/1.1"]

--- a/src/hypercorn/logging.py
+++ b/src/hypercorn/logging.py
@@ -25,6 +25,7 @@ def _create_logger(
     target: Union[logging.Logger, str, None],
     level: Optional[str],
     sys_default: IO,
+    formatter,
     *,
     propagate: bool = True,
 ) -> Optional[logging.Logger]:
@@ -37,10 +38,6 @@ def _create_logger(
             logging.StreamHandler(sys_default) if target == "-" else logging.FileHandler(target)  # type: ignore # noqa: E501
         ]
         logger.propagate = propagate
-        formatter = logging.Formatter(
-            "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
-            "[%Y-%m-%d %H:%M:%S %z]",
-        )
         logger.handlers[0].setFormatter(formatter)
         if level is not None:
             logger.setLevel(logging.getLevelName(level.upper()))
@@ -57,11 +54,17 @@ class Logger:
             "hypercorn.access",
             config.accesslog,
             config.loglevel,
-            sys.stdout,
-            propagate=False,
+            config.access_log_sys_default,
+            config.log_formatter,
+            propagate=config.propagate_access_log,
         )
         self.error_logger = _create_logger(
-            "hypercorn.error", config.errorlog, config.loglevel, sys.stderr
+            "hypercorn.error",
+            config.errorlog,
+            config.loglevel,
+            config.error_log_sys_default,
+            config.log_formatter,
+            propagate=config.propagate_error_log
         )
 
         if config.logconfig is not None:


### PR DESCRIPTION
This enables customization by the developer (all while preserving the existing default behavior).

Usage example:

```
hypercorn.Config.log_formatter = logging.Formatter(fmt=log_format, datefmt=log_date_format)
hypercorn.Config.propagate_error_log = False
hypercorn.Config.error_log_sys_default = sys.stdout
```