### PR TITLE
Only load the application in the main process if the reloader is being used.

### DIFF
--- a/src/hypercorn/run.py
+++ b/src/hypercorn/run.py
@@ -37,9 +37,10 @@ def run(config: Config) -> None:
 
     sockets = config.create_sockets()
 
-    # Load the application so that the correct paths are checked for
-    # changes.
-    load_application(config.application_path, config.wsgi_max_body_size)
+    if config.use_reloader:
+        # Load the application so that the correct paths are checked for
+        # changes, but only when the reloader is being used.
+        load_application(config.application_path, config.wsgi_max_body_size)
 
     ctx = get_context("spawn")
 


### PR DESCRIPTION
I was noticing higher than expected cold boot times and noticed a lot of duplicate imports, and tracked it down to loading the application in the main process, and again in the sub-processes.  I also saw https://github.com/pgjones/hypercorn/issues/101 when looking at existing issues.  

To that end I've adjusted the loading of the application in the main process to only load when reloading is being used, which based on the comments seems to be the reason it's loaded in the main process. 

