### PR TITLE
Relax shutdown_trigger annotation

### DIFF
--- a/src/hypercorn/asyncio/__init__.py
+++ b/src/hypercorn/asyncio/__init__.py
@@ -13,7 +13,7 @@ async def serve(
     app: Framework,
     config: Config,
     *,
-    shutdown_trigger: Optional[Callable[..., Awaitable[None]]] = None,
+    shutdown_trigger: Optional[Callable[..., Awaitable]] = None,
     mode: Optional[Literal["asgi", "wsgi"]] = None,
 ) -> None:
     """Serve an ASGI or WSGI framework app given the config.

--- a/src/hypercorn/asyncio/run.py
+++ b/src/hypercorn/asyncio/run.py
@@ -45,7 +45,7 @@ async def worker_serve(
     config: Config,
     *,
     sockets: Optional[Sockets] = None,
-    shutdown_trigger: Optional[Callable[..., Awaitable[None]]] = None,
+    shutdown_trigger: Optional[Callable[..., Awaitable]] = None,
 ) -> None:
     config.set_statsd_logger_class(StatsdLogger)
 

--- a/src/hypercorn/utils.py
+++ b/src/hypercorn/utils.py
@@ -164,7 +164,7 @@ def wait_for_changes(shutdown_event: EventType) -> None:
                     last_updates[path] = mtime
 
 
-async def raise_shutdown(shutdown_event: Callable[..., Awaitable[None]]) -> None:
+async def raise_shutdown(shutdown_event: Callable[..., Awaitable]) -> None:
     await shutdown_event()
     raise ShutdownError()
 


### PR DESCRIPTION
I relaxed the shutdown_trigger annotation to only take an `Awaitable` (a shorthand for `Awaitable[Any]`, imo more readable and not requiring an import).

I don't think there's a reason for the trigger to be annotated as `Awaitable[None]` since we don't care about the return value, and it makes it not type-check with an asyncio Event, which is a common use case.