### PR TITLE
Add logging to h11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ docs/reference/source/
 dist/
 .coverage
 poetry.lock
+
+# Pycharm
+.idea/

--- a/src/hypercorn/protocol/h11.py
+++ b/src/hypercorn/protocol/h11.py
@@ -155,7 +155,9 @@ class H11Protocol:
             try:
                 event = self.connection.next_event()
             except h11.RemoteProtocolError as e:
-                await self.config.log.exception("RemoteProtocolError processing event chain", exc_info=e)
+                await self.config.log.exception(
+                    "RemoteProtocolError processing event chain", exc_info=e
+                )
                 if self.connection.our_state in {h11.IDLE, h11.SEND_RESPONSE}:
                     await self._send_error_response(400)
                 await self.send(Closed())
@@ -235,7 +237,11 @@ class H11Protocol:
             data = self.connection.send(event)
         except h11.LocalProtocolError as e:
             if self.connection.their_state != h11.ERROR:
-                await self.config.log.exception("LocalProtocolError processing event and client state not error", self.connection.their_state, exc_info=e)
+                await self.config.log.exception(
+                    "LocalProtocolError processing event and client state not error",
+                    self.connection.their_state,
+                    exc_info=e,
+                )
                 raise
         else:
             await self.send(RawData(data=data))


### PR DESCRIPTION
Just starting with h11 since that's what our frontend <> backend uses.

I'm gonna stick with the existing `error_logger`, we can configure to emit stuff from candid-api.