### PR TITLE
If use-reloader is set:\

### DIFF
--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -243,7 +243,7 @@ class Config:
                 except (ValueError, IndexError):
                     host, port = bind, 8000
                 sock = socket.socket(socket.AF_INET6 if ":" in host else socket.AF_INET, type_)
-                if self.workers > 1:
+                if self.workers > 1 or self.use_reloader:
                     try:
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
                     except AttributeError:


### PR DESCRIPTION
 tries to re-use the exising binds to create the new sockets.

Ran into an issue where when triggering reload on an insecure bind getting an error message stating that the socket is already in use. Documented in #151 