### PR TITLE
Update WSGIWrapper to be spec compliant (pep 333/3333).

### DIFF
--- a/src/hypercorn/app_wrappers.py
+++ b/src/hypercorn/app_wrappers.py
@@ -102,7 +102,7 @@ class WSGIWrapper:
                 for name, value in response_headers
             ]
 
-        def send_headers(content_length: int):
+        def send_headers(content_length: int) -> None:
             nonlocal headers, headers_sent
             if not headers:
                 raise AssertionError("missing call to start_response")
@@ -115,7 +115,7 @@ class WSGIWrapper:
             send({"type": "http.response.start", "status": status_code, "headers": headers})
             headers_sent = True
 
-        def send_body(data: bytes = b"", more_body: bool = False):
+        def send_body(data: bytes = b"", more_body: bool = False) -> None:
             if not headers_sent:
                 send_headers(len(data))
             send({"type": "http.response.body", "body": data, "more_body": more_body})
@@ -124,7 +124,7 @@ class WSGIWrapper:
 
         body_part_count: Optional[int] = None
         if hasattr(response_body, "__len__"):
-            body_part_count = len(response_body)
+            body_part_count = len(response_body)  # type: ignore
 
         try:
             # Optimize the common case of one body part

--- a/src/hypercorn/app_wrappers.py
+++ b/src/hypercorn/app_wrappers.py
@@ -132,6 +132,7 @@ class WSGIWrapper:
                 implicit_content_length = True
                 send_body(next(iter(response_body)))
             elif body_part_count == 0:
+                implicit_content_length = True
                 send_body()
             else:
                 for idx, output in enumerate(response_body, start=1):

--- a/src/hypercorn/app_wrappers.py
+++ b/src/hypercorn/app_wrappers.py
@@ -134,10 +134,12 @@ class WSGIWrapper:
             elif body_part_count == 0:
                 send_body()
             else:
-                for output in response_body:
+                for idx, output in enumerate(response_body, start=1):
                     if output:
-                        send_body(output, more_body=True)
-                send_body()
+                        more_body = body_part_count is None or idx != body_part_count
+                        send_body(output, more_body=more_body)
+                if body_part_count is None:
+                    send_body()
         finally:
             if hasattr(response_body, "close"):
                 response_body.close()

--- a/src/hypercorn/typing.py
+++ b/src/hypercorn/typing.py
@@ -217,6 +217,7 @@ ASGIFramework = Callable[
     ],
     Awaitable[None],
 ]
+# TODO: Iterable[bytes] is not really the correct return type as it misses .close()/.__len__()
 WSGIFramework = Callable[[dict, Callable], Iterable[bytes]]
 Framework = Union[ASGIFramework, WSGIFramework]
 

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
-from typing import Any, Callable, Iterable, List
+from typing import Any, Callable, Iterable, List, Self
 
 import pytest
 import trio
@@ -27,7 +27,7 @@ class ResponseHelperBase:
     def __init__(self, body_parts: list[bytes] = []):
         self.body_parts = iter(body_parts)
 
-    def __iter__(self):
+    def __iter__(self) -> Self:
         return self
 
     def __next__(self) -> bytes:
@@ -58,7 +58,9 @@ def simple_wsgi_app(response: ResponseHelperBase) -> WSGIFramework:
     return app
 
 
-async def wsgi_helper(wsgi_app: WSGIFramework, event_loop: asyncio.AbstractEventLoop) -> list[dict]:
+async def wsgi_helper(
+    wsgi_app: WSGIFramework, event_loop: asyncio.AbstractEventLoop
+) -> list[ASGISendEvent]:
     app = WSGIWrapper(wsgi_app, 2**16)
     scope: HTTPScope = {
         "http_version": "1.1",

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from functools import partial
-from typing import Any, Callable, List
+from typing import Any, Callable, Iterable, List
 
 import pytest
 import trio
 
 from hypercorn.app_wrappers import _build_environ, InvalidPathError, WSGIWrapper
-from hypercorn.typing import ASGISendEvent, HTTPScope
+from hypercorn.typing import ASGISendEvent, HTTPScope, WSGIFramework
 
 
 def echo_body(environ: dict, start_response: Callable) -> List[bytes]:
@@ -19,6 +19,155 @@ def echo_body(environ: dict, start_response: Callable) -> List[bytes]:
     ]
     start_response(status, headers)
     return [output]
+
+
+class ResponseHelperBase:
+    close_called: bool = False
+
+    def __init__(self, body_parts: list[bytes] = []):
+        self.body_parts = iter(body_parts)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> bytes:
+        return next(self.body_parts)
+
+    def close(self) -> None:
+        self.close_called = True
+
+
+class ResponseHelper(ResponseHelperBase):
+    def __init__(self, body_parts: list[bytes] = []):
+        self.length = len(body_parts)
+        super().__init__(body_parts)
+
+    def __len__(self) -> int:
+        return self.length
+
+
+def simple_wsgi_app(response: ResponseHelperBase) -> WSGIFramework:
+    def app(environ: dict, start_response: Callable) -> Iterable[bytes]:
+        status = "200 OK"
+        headers = [
+            ("Content-Type", "text/plain; charset=utf-8"),
+        ]
+        start_response(status, headers)
+        return response
+
+    return app
+
+
+async def wsgi_helper(wsgi_app: WSGIFramework, event_loop: asyncio.AbstractEventLoop) -> list[dict]:
+    app = WSGIWrapper(wsgi_app, 2**16)
+    scope: HTTPScope = {
+        "http_version": "1.1",
+        "asgi": {},
+        "method": "GET",
+        "headers": [],
+        "path": "/",
+        "root_path": "/",
+        "query_string": b"a=b",
+        "raw_path": b"/",
+        "scheme": "http",
+        "type": "http",
+        "client": ("localhost", 80),
+        "server": None,
+        "extensions": {},
+    }
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put({"type": "http.request"})
+
+    messages = []
+
+    async def _send(message: ASGISendEvent) -> None:
+        nonlocal messages
+        messages.append(message)
+
+    def _call_soon(func: Callable, *args: Any) -> Any:
+        future = asyncio.run_coroutine_threadsafe(func(*args), event_loop)
+        return future.result()
+
+    await app(scope, queue.get, _send, partial(event_loop.run_in_executor, None), _call_soon)
+    return messages
+
+
+@pytest.mark.asyncio
+async def test_wsgi_close(event_loop: asyncio.AbstractEventLoop) -> None:
+    response = ResponseHelper([b"testing close"])
+    await wsgi_helper(simple_wsgi_app(response), event_loop)
+    assert response.close_called
+
+
+@pytest.mark.asyncio
+async def test_implicit_content_type(event_loop: asyncio.AbstractEventLoop) -> None:
+    response = ResponseHelper([b"testing len"])
+    messages = await wsgi_helper(simple_wsgi_app(response), event_loop)
+    assert messages == [
+        {
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"content-length", b"11"),
+            ],
+            "status": 200,
+            "type": "http.response.start",
+        },
+        {"body": bytearray(b"testing len"), "type": "http.response.body", "more_body": False},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_content_type(event_loop: asyncio.AbstractEventLoop) -> None:
+    response = ResponseHelperBase([b"testing len"])
+    messages = await wsgi_helper(simple_wsgi_app(response), event_loop)
+    assert messages == [
+        {
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+            ],
+            "status": 200,
+            "type": "http.response.start",
+        },
+        {"body": bytearray(b"testing len"), "type": "http.response.body", "more_body": True},
+        {"body": bytearray(b""), "type": "http.response.body", "more_body": False},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiple_parts(event_loop: asyncio.AbstractEventLoop) -> None:
+    response = ResponseHelperBase([b"testing", b" ", b"parts"])
+    messages = await wsgi_helper(simple_wsgi_app(response), event_loop)
+    assert messages == [
+        {
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+            ],
+            "status": 200,
+            "type": "http.response.start",
+        },
+        {"body": bytearray(b"testing"), "type": "http.response.body", "more_body": True},
+        {"body": bytearray(b" "), "type": "http.response.body", "more_body": True},
+        {"body": bytearray(b"parts"), "type": "http.response.body", "more_body": True},
+        {"body": bytearray(b""), "type": "http.response.body", "more_body": False},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiple_parts_with_length(event_loop: asyncio.AbstractEventLoop) -> None:
+    response = ResponseHelper([b"testing", b" ", b"parts"])
+    messages = await wsgi_helper(simple_wsgi_app(response), event_loop)
+    assert messages == [
+        {
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+            ],
+            "status": 200,
+            "type": "http.response.start",
+        },
+        {"body": bytearray(b"testing"), "type": "http.response.body", "more_body": True},
+        {"body": bytearray(b" "), "type": "http.response.body", "more_body": True},
+        {"body": bytearray(b"parts"), "type": "http.response.body", "more_body": False},
+    ]
 
 
 @pytest.mark.trio

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -16,7 +16,6 @@ def echo_body(environ: dict, start_response: Callable) -> List[bytes]:
     output = environ["wsgi.input"].read()
     headers = [
         ("Content-Type", "text/plain; charset=utf-8"),
-        ("Content-Length", str(len(output))),
     ]
     start_response(status, headers)
     return [output]
@@ -56,7 +55,6 @@ async def test_wsgi_trio() -> None:
             "status": 200,
             "type": "http.response.start",
         },
-        {"body": bytearray(b""), "type": "http.response.body", "more_body": True},
         {"body": bytearray(b""), "type": "http.response.body", "more_body": False},
     ]
 
@@ -99,7 +97,6 @@ async def test_wsgi_asyncio(event_loop: asyncio.AbstractEventLoop) -> None:
             "status": 200,
             "type": "http.response.start",
         },
-        {"body": bytearray(b""), "type": "http.response.body", "more_body": True},
         {"body": bytearray(b""), "type": "http.response.body", "more_body": False},
     ]
 


### PR DESCRIPTION
The commit contains the following changes:

 * Error out early if the application forgets to call start_response
 * Send a proper content-length if the iterable returned has only one item
 * Always call `close()` on the returned iterable if it exists.

This potentially fixes #154. Haven't looked at tests yet, but should provide a base for discussion…