### PR TITLE
Log on h11 RemoteProtocolError, properly punch through 431

### DIFF
--- a/src/hypercorn/protocol/h11.py
+++ b/src/hypercorn/protocol/h11.py
@@ -154,9 +154,12 @@ class H11Protocol:
 
             try:
                 event = self.connection.next_event()
-            except h11.RemoteProtocolError:
+            except h11.RemoteProtocolError as e:
+                await self.config.log.info(
+                    "RemoteProtocolError processing event chain", exc_info=e
+                )
                 if self.connection.our_state in {h11.IDLE, h11.SEND_RESPONSE}:
-                    await self._send_error_response(400)
+                    await self._send_error_response(e.error_status_hint)
                 await self.send(Closed())
                 break
             else:

--- a/tests/protocol/test_h11.py
+++ b/tests/protocol/test_h11.py
@@ -302,7 +302,7 @@ async def test_protocol_handle_max_incomplete(monkeypatch: MonkeyPatch) -> None:
     assert protocol.send.call_args_list == [  # type: ignore
         call(
             RawData(
-                data=b"HTTP/1.1 400 \r\ncontent-length: 0\r\nconnection: close\r\n"
+                data=b"HTTP/1.1 431 \r\ncontent-length: 0\r\nconnection: close\r\n"
                 b"date: Thu, 01 Jan 1970 01:23:20 GMT\r\nserver: hypercorn-h11\r\n\r\n"
             )
         ),


### PR DESCRIPTION
Fixes https://github.com/pgjones/hypercorn/issues/157

We had a tough time trying to debug an issue where our stack was 400ing without telemetry. We were able to trace it back to our large headers putting us over the `h11_max_incomplete_size` so the request was being rejected in hypercorn before making it to our FastAPI backend.

I think it would be best to punch through the 431 coming out of h11 as well as emit a log here. I went with an info-level log since this could be a client error (at least in this case it is). Definitely open to feedback or other ideas on that!