### PR TITLE
h2/h3 trailing header support. Fixes #147

### DIFF
--- a/src/hypercorn/protocol/events.py
+++ b/src/hypercorn/protocol/events.py
@@ -28,6 +28,11 @@ class EndBody(Event):
 
 
 @dataclass(frozen=True)
+class Trailers(Event):
+    headers: List[Tuple[bytes, bytes]]
+
+
+@dataclass(frozen=True)
 class Data(Event):
     data: bytes
 

--- a/src/hypercorn/protocol/h2.py
+++ b/src/hypercorn/protocol/h2.py
@@ -18,6 +18,7 @@ from .events import (
     Request,
     Response,
     StreamClosed,
+    Trailers,
 )
 from .http_stream import HTTPStream
 from .ws_stream import WSStream
@@ -212,6 +213,9 @@ class H2Protocol:
                 self.priority.unblock(event.stream_id)
                 await self.has_data.set()
                 await self.stream_buffers[event.stream_id].drain()
+            elif isinstance(event, Trailers):
+                self.connection.send_headers(event.stream_id, event.headers)
+                await self._flush()
             elif isinstance(event, StreamClosed):
                 await self._close_stream(event.stream_id)
                 idle = len(self.streams) == 0 or all(

--- a/src/hypercorn/protocol/h3.py
+++ b/src/hypercorn/protocol/h3.py
@@ -18,6 +18,7 @@ from .events import (
     Request,
     Response,
     StreamClosed,
+    Trailers,
 )
 from .http_stream import HTTPStream
 from .ws_stream import WSStream
@@ -78,6 +79,9 @@ class H3Protocol:
             await self.send()
         elif isinstance(event, (EndBody, EndData)):
             self.connection.send_data(event.stream_id, b"", True)
+            await self.send()
+        elif isinstance(event, Trailers):
+            self.connection.send_headers(event.stream_id, event.headers)
             await self.send()
         elif isinstance(event, StreamClosed):
             pass  # ??

--- a/src/hypercorn/typing.py
+++ b/src/hypercorn/typing.py
@@ -83,12 +83,19 @@ class HTTPResponseStartEvent(TypedDict):
     type: Literal["http.response.start"]
     status: int
     headers: Iterable[Tuple[bytes, bytes]]
+    trailers: Optional[bool]
 
 
 class HTTPResponseBodyEvent(TypedDict):
     type: Literal["http.response.body"]
     body: bytes
     more_body: bool
+
+
+class HTTPResponseTrailersEvent(TypedDict):
+    type: Literal["http.response.trailers"]
+    headers: Iterable[Tuple[bytes, bytes]]
+    more_trailers: bool
 
 
 class HTTPServerPushEvent(TypedDict):
@@ -191,6 +198,7 @@ ASGIReceiveEvent = Union[
 ASGISendEvent = Union[
     HTTPResponseStartEvent,
     HTTPResponseBodyEvent,
+    HTTPResponseTrailersEvent,
     HTTPServerPushEvent,
     HTTPEarlyHintEvent,
     HTTPDisconnectEvent,

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -83,7 +83,11 @@ async def test_handle_request_http_2(stream: HTTPStream) -> None:
         "headers": [],
         "client": None,
         "server": None,
-        "extensions": {"http.response.early_hint": {}, "http.response.push": {}},
+        "extensions": {
+            "http.response.trailers": {},
+            "http.response.early_hint": {},
+            "http.response.push": {},
+        },
     }
 
 


### PR DESCRIPTION
This is an initial implementation of trailing header suppport for http2/http3. This fixes #147, in theory.

Here's the thing though...I have no clue what I am doing. I would like some tips on how to do the following:
1) Ensure that I am following the asgi spec properly
2) Ensure that I am following the HTTP/2 HTTP/3 spec properly

I assume the underlying `h2` and `h3` libraries take care of (2) for me, but I'm not sure.