### PR TITLE
Rename ssl to tls

### DIFF
--- a/src/hypercorn/asyncio/tcp_server.py
+++ b/src/hypercorn/asyncio/tcp_server.py
@@ -47,10 +47,10 @@ class TCPServer:
             server = parse_socket_addr(socket.family, socket.getsockname())
             ssl_object = self.writer.get_extra_info("ssl_object")
             if ssl_object is not None:
-                ssl = True
+                tls = True
                 alpn_protocol = ssl_object.selected_alpn_protocol()
             else:
-                ssl = False
+                tls = False
                 alpn_protocol = "http/1.1"
 
             async with TaskGroup(self.loop) as task_group:
@@ -59,7 +59,7 @@ class TCPServer:
                     self.config,
                     self.context,
                     task_group,
-                    ssl,
+                    tls,
                     client,
                     server,
                     self.protocol_send,

--- a/src/hypercorn/protocol/__init__.py
+++ b/src/hypercorn/protocol/__init__.py
@@ -16,7 +16,7 @@ class ProtocolWrapper:
         config: Config,
         context: WorkerContext,
         task_group: TaskGroup,
-        ssl: bool,
+        tls: bool,
         client: Optional[Tuple[str, int]],
         server: Optional[Tuple[str, int]],
         send: Callable[[Event], Awaitable[None]],
@@ -26,7 +26,7 @@ class ProtocolWrapper:
         self.config = config
         self.context = context
         self.task_group = task_group
-        self.ssl = ssl
+        self.tls = tls
         self.client = client
         self.server = server
         self.send = send
@@ -37,7 +37,7 @@ class ProtocolWrapper:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.send,
@@ -48,7 +48,7 @@ class ProtocolWrapper:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.send,
@@ -66,7 +66,7 @@ class ProtocolWrapper:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.send,
@@ -80,7 +80,7 @@ class ProtocolWrapper:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.send,

--- a/src/hypercorn/protocol/h11.py
+++ b/src/hypercorn/protocol/h11.py
@@ -84,7 +84,7 @@ class H11Protocol:
         config: Config,
         context: WorkerContext,
         task_group: TaskGroup,
-        ssl: bool,
+        tls: bool,
         client: Optional[Tuple[str, int]],
         server: Optional[Tuple[str, int]],
         send: Callable[[Event], Awaitable[None]],
@@ -99,7 +99,7 @@ class H11Protocol:
         self.context = context
         self.send = send
         self.server = server
-        self.ssl = ssl
+        self.tls = tls
         self.stream: Optional[Union[HTTPStream, WSStream]] = None
         self.task_group = task_group
 
@@ -200,7 +200,7 @@ class H11Protocol:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.stream_send,
@@ -213,7 +213,7 @@ class H11Protocol:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.stream_send,

--- a/src/hypercorn/protocol/h2.py
+++ b/src/hypercorn/protocol/h2.py
@@ -84,7 +84,7 @@ class H2Protocol:
         config: Config,
         context: WorkerContext,
         task_group: TaskGroup,
-        ssl: bool,
+        tls: bool,
         client: Optional[Tuple[str, int]],
         server: Optional[Tuple[str, int]],
         send: Callable[[Event], Awaitable[None]],
@@ -111,7 +111,7 @@ class H2Protocol:
 
         self.send = send
         self.server = server
-        self.ssl = ssl
+        self.tls = tls
         self.streams: Dict[int, Union[HTTPStream, WSStream]] = {}
         # The below are used by the sending task
         self.has_data = self.context.event_class()
@@ -313,7 +313,7 @@ class H2Protocol:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.stream_send,
@@ -325,7 +325,7 @@ class H2Protocol:
                 self.config,
                 self.context,
                 self.task_group,
-                self.ssl,
+                self.tls,
                 self.client,
                 self.server,
                 self.stream_send,

--- a/src/hypercorn/protocol/http_stream.py
+++ b/src/hypercorn/protocol/http_stream.py
@@ -42,7 +42,7 @@ class HTTPStream:
         config: Config,
         context: WorkerContext,
         task_group: TaskGroup,
-        ssl: bool,
+        tls: bool,
         client: Optional[Tuple[str, int]],
         server: Optional[Tuple[str, int]],
         send: Callable[[Event], Awaitable[None]],
@@ -56,7 +56,7 @@ class HTTPStream:
         self.response: HTTPResponseStartEvent
         self.scope: HTTPScope
         self.send = send
-        self.scheme = "https" if ssl else "http"
+        self.scheme = "https" if tls else "http"
         self.server = server
         self.start_time: float
         self.state = ASGIHTTPState.REQUEST

--- a/src/hypercorn/protocol/ws_stream.py
+++ b/src/hypercorn/protocol/ws_stream.py
@@ -167,7 +167,7 @@ class WSStream:
         config: Config,
         context: WorkerContext,
         task_group: TaskGroup,
-        ssl: bool,
+        tls: bool,
         client: Optional[Tuple[str, int]],
         server: Optional[Tuple[str, int]],
         send: Callable[[Event], Awaitable[None]],
@@ -185,7 +185,7 @@ class WSStream:
         self.scope: WebsocketScope
         self.send = send
         # RFC 8441 for HTTP/2 says use http or https, ASGI says ws or wss
-        self.scheme = "wss" if ssl else "ws"
+        self.scheme = "wss" if tls else "ws"
         self.server = server
         self.start_time: float
         self.state = ASGIWebsocketState.HANDSHAKE

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -42,11 +42,11 @@ class TCPServer:
                 return  # Handshake failed
             alpn_protocol = self.stream.selected_alpn_protocol()
             socket = self.stream.transport_stream.socket
-            ssl = True
+            tls = True
         except AttributeError:  # Not SSL
             alpn_protocol = "http/1.1"
             socket = self.stream.socket
-            ssl = False
+            tls = False
 
         try:
             client = parse_socket_addr(socket.family, socket.getpeername())
@@ -59,7 +59,7 @@ class TCPServer:
                     self.config,
                     self.context,
                     task_group,
-                    ssl,
+                    tls,
                     client,
                     server,
                     self.protocol_send,


### PR DESCRIPTION
The ssl name clashes with the ssl module name and I intend to reuse this variable to carry information about the ASGI TLS extension.