### PR TITLE
If any subprocess's exit code is non-zero our exit code should also be non-zero.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ docs/reference/source/
 dist/
 .coverage
 poetry.lock
+.idea/
+.DS_Store

--- a/src/hypercorn/__main__.py
+++ b/src/hypercorn/__main__.py
@@ -23,7 +23,7 @@ def _load_config(config_path: Optional[str]) -> Config:
         return Config.from_toml(config_path)
 
 
-def main(sys_args: Optional[List[str]] = None) -> None:
+def main(sys_args: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "application", help="The application to dispatch to as path.to.module:instance.path"
@@ -284,8 +284,8 @@ def main(sys_args: Optional[List[str]] = None) -> None:
     if len(args.server_names) > 0:
         config.server_names = args.server_names
 
-    run(config)
+    return run(config)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/hypercorn/run.py
+++ b/src/hypercorn/run.py
@@ -15,7 +15,9 @@ from .typing import WorkerFunc
 from .utils import load_application, wait_for_changes, write_pid_file
 
 
-def run(config: Config) -> None:
+def run(config: Config) -> int:
+    exit_code = 0
+
     if config.pid_path is not None:
         write_pid_file(config.pid_path)
 
@@ -80,13 +82,19 @@ def run(config: Config) -> None:
 
         for process in processes:
             process.join()
+            if process.exitcode != 0:
+                exit_code = process.exitcode
+
         for process in processes:
             process.terminate()
 
         for sock in sockets.secure_sockets:
             sock.close()
+
         for sock in sockets.insecure_sockets:
             sock.close()
+
+    return exit_code
 
 
 def start_processes(


### PR DESCRIPTION
Simply put, if any of our subprocesses exits with a non-zero exit code, we should also exit with a non-zero exit code. This is very important for example in scenarios where hypercorn fails to even start due to (e.g. due to Lifespan exceptions). 

Currently, when this happens, hypercorn's process exits with a status code of zero, i.e. success. This prevents systemd and its equivalents from identifying that the process has failed and should be restarted (e.g. when the service is set with Restart=on-failure).