### PR TITLE
Remove old warning

### DIFF
--- a/docs/how_to_guides/wsgi_apps.rst
+++ b/docs/how_to_guides/wsgi_apps.rst
@@ -9,12 +9,6 @@ Hypercorn directly serves WSGI applications:
 
     $ hypercorn module:wsgi_app
 
-.. warning::
-
-    The full response from the WSGI app will be stored in memory
-    before being sent. This prevents the WSGI app from streaming a
-    response.
-
 WSGI Middleware
 ---------------
 


### PR DESCRIPTION
I don't think the warning is true anymore. We are sending multiple body parts:
https://github.com/pgjones/hypercorn/blob/2d2c62bac7b83a8c6766fe3a517f63ff842e5c38/src/hypercorn/app_wrappers.py#L117
 so we are streaming? Or am I missing something?