### PR TITLE
Drop exceptiongroup dependency in Python 3.11 and later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ documentation = "https://hypercorn.readthedocs.io"
 [tool.poetry.dependencies]
 python = ">=3.8"
 aioquic = { version = ">= 0.9.0, < 1.0", optional = true }
-exceptiongroup = ">= 1.1.0"
+exceptiongroup = { version = ">= 1.1.0", python = "<3.11" }
 h11 = "*"
 h2 = ">=3.1.0"
 priority = "*"


### PR DESCRIPTION
All of the imports are already conditionalized on the Python interpreter version; there is no need to install this backport package on current interpreters, Python 3.11 and later.

https://github.com/pgjones/hypercorn/blob/3fbd5f245e5dfeaba6ad852d9135d6a32b228d05/src/hypercorn/trio/task_group.py#L12-L13

https://github.com/pgjones/hypercorn/blob/3fbd5f245e5dfeaba6ad852d9135d6a32b228d05/src/hypercorn/trio/run.py#L26-L27

https://github.com/pgjones/hypercorn/blob/3fbd5f245e5dfeaba6ad852d9135d6a32b228d05/src/hypercorn/asyncio/run.py#L40-L41