### PR TITLE
Handle already-closed http/2 stream

### DIFF
--- a/src/hypercorn/protocol/h2.py
+++ b/src/hypercorn/protocol/h2.py
@@ -256,7 +256,11 @@ class H2Protocol:
                     event.flow_controlled_length, event.stream_id
                 )
             elif isinstance(event, h2.events.StreamEnded):
-                await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))
+                try:
+                    await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))
+                except KeyError:
+                    # Connection was already closed for some reason
+                    pass
             elif isinstance(event, h2.events.StreamReset):
                 await self._close_stream(event.stream_id)
                 await self._window_updated(event.stream_id)


### PR DESCRIPTION
This is a patch for issue #197, where the HTTP/2 protocol handler receives an event for an already-closed stream. This change just silently ignores the error.

If someone can address the error more robustly, please do; but it doesn't affect the client experience as far as I have been able to tell.