### PR TITLE
Allow signaling shutdown during startup lifespan event when using Trio

### DIFF
--- a/src/hypercorn/asyncio/lifespan.py
+++ b/src/hypercorn/asyncio/lifespan.py
@@ -50,18 +50,23 @@ class Lifespan:
         except LifespanFailureError:
             # Lifespan failures should crash the server
             raise
-        except Exception:
+        except Exception as exception:
+
             self.supported = False
             if not self.startup.is_set():
                 await self.config.log.warning(
-                    "ASGI Framework Lifespan error, continuing without Lifespan support"
+                    f"ASGI Framework Lifespan error, continuing without Lifespan support: "
+                    f"{str(exception)}"
                 )
             elif not self.shutdown.is_set():
                 await self.config.log.exception(
-                    "ASGI Framework Lifespan error, shutdown without Lifespan support"
+                    f"ASGI Framework Lifespan error, shutdown without Lifespan support: "
+                    f"{str(exception)}"
                 )
             else:
-                await self.config.log.exception("ASGI Framework Lifespan errored after shutdown.")
+                await self.config.log.exception(
+                    f"ASGI Framework Lifespan errored after shutdown: {str(exception)}"
+                )
         finally:
             self.startup.set()
             self.shutdown.set()

--- a/src/hypercorn/trio/lifespan.py
+++ b/src/hypercorn/trio/lifespan.py
@@ -41,18 +41,25 @@ class Lifespan:
         except LifespanFailureError:
             # Lifespan failures should crash the server
             raise
-        except Exception:
+        except Exception as exception:
+            if isinstance(exception, ExceptionGroup) and len(exception.exceptions) == 1:
+                exception = exception.exceptions[0]
+
             self.supported = False
             if not self.startup.is_set():
                 await self.config.log.warning(
-                    "ASGI Framework Lifespan error, continuing without Lifespan support"
+                    f"ASGI Framework Lifespan error, continuing without Lifespan support: "
+                    f"{str(exception)}"
                 )
             elif not self.shutdown.is_set():
                 await self.config.log.exception(
-                    "ASGI Framework Lifespan error, shutdown without Lifespan support"
+                    f"ASGI Framework Lifespan error, shutdown without Lifespan support: "
+                    f"{str(exception)}"
                 )
             else:
-                await self.config.log.exception("ASGI Framework Lifespan errored after shutdown.")
+                await self.config.log.exception(
+                    f"ASGI Framework Lifespan errored after shutdown: {str(exception)}"
+                )
         finally:
             self.startup.set()
             self.shutdown.set()

--- a/src/hypercorn/trio/run.py
+++ b/src/hypercorn/trio/run.py
@@ -47,6 +47,11 @@ async def worker_serve(
         await lifespan_nursery.start(lifespan.handle_lifespan)
         await lifespan.wait_for_startup()
 
+        if lifespan.shutdown.is_set():
+            await lifespan.wait_for_shutdown()
+            lifespan_nursery.cancel_scope.cancel()
+            return
+
         async with trio.open_nursery() as server_nursery:
             if sockets is None:
                 sockets = config.create_sockets()


### PR DESCRIPTION
Without this, a failure that's triggered during the startup phase does not prompt aborting of the startup process and the server proceeds to finish loading and wait for incoming requests.