### PR TITLE
Set TCP_NODELAY on sockets

### DIFF
--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -246,6 +246,7 @@ class Config:
                 except (ValueError, IndexError):
                     host, port = bind, 8000
                 sock = socket.socket(socket.AF_INET6 if ":" in host else socket.AF_INET, type_)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 if self.workers > 1:
                     try:
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)


### PR DESCRIPTION
This brings it in line with what I think people will expect, since both trio and asyncio (as well as seemingly most other networking libraries) set it by default.
trio discussions at https://github.com/python-trio/trio/issues/72 and https://github.com/python-trio/trio/issues/1792
asyncio: https://docs.python.org/3.6/library/asyncio-protocol.html
aiohttp: https://github.com/aio-libs/aiohttp/issues/664