### PR TITLE
Fix bad disconnects in HTTP/1.1 with keep_alive_max_requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ uvloop = { version = "*", markers = "platform_system != 'Windows'", optional = t
 wsproto = ">=0.14.0"
 
 [tool.poetry.dev-dependencies]
+httpx = "*"
 hypothesis = "*"
 mock = "*"
 pytest = "*"

--- a/tests/e2e/exercise_e2e.py
+++ b/tests/e2e/exercise_e2e.py
@@ -1,0 +1,45 @@
+import hypercorn.trio
+from hypercorn.config import Config
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+import trio
+import httpx
+
+
+async def test_post(request: Request):
+    print("HEY")
+    return Response("boo", 200)
+
+async def run_test():
+    app = Starlette(
+        routes=[
+            Route( "/test", test_post, methods=["POST"])
+        ]
+    )
+
+    config = Config()
+    config.bind = f"0.0.0.0:1234"
+    config.accesslog = "-"  # Log to stdout/err
+    config.errorlog = "-"
+    config.keep_alive_max_requests = 2
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(hypercorn.trio.serve, app, config)
+
+        await trio.sleep(0.1)
+
+        client = httpx.AsyncClient()
+        for _ in range(10):
+            msg = {"key": "key1", "value": "value1"}
+            try:
+                result = await client.post("http://0.0.0.0:1234/test", json=msg)
+            except (httpx.ReadError, httpx.RemoteProtocolError):
+                raise
+            result.raise_for_status()
+            print(result)
+
+if __name__ == "__main__":
+    trio.run(run_test)

--- a/tests/e2e/exercise_e2e.py
+++ b/tests/e2e/exercise_e2e.py
@@ -1,25 +1,25 @@
 import hypercorn.trio
 from hypercorn.config import Config
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.requests import Request
-from starlette.responses import Response
-from starlette.routing import Route
 import trio
 import httpx
 
 
-async def test_post(request: Request):
-    print("HEY")
-    return Response("boo", 200)
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+
+    await send({
+        'type': 'http.response.start',
+        'status': 200,
+        'headers': [
+            [b'content-type', b'text/plain'],
+        ],
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': b'Hello, world!',
+    })
 
 async def run_test():
-    app = Starlette(
-        routes=[
-            Route( "/test", test_post, methods=["POST"])
-        ]
-    )
-
     config = Config()
     config.bind = f"0.0.0.0:1234"
     config.accesslog = "-"  # Log to stdout/err

--- a/tests/e2e/test_httpx.py
+++ b/tests/e2e/test_httpx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hypercorn.trio
 from hypercorn.config import Config
 import trio
@@ -20,16 +22,18 @@ async def app(scope, receive, send):
         'body': b'Hello, world!',
     })
 
+
 @pytest.mark.trio
 async def test_keep_alive_max_requests_regression():
     config = Config()
-    config.bind = f"0.0.0.0:1234"
+    config.bind = "0.0.0.0:1234"
     config.accesslog = "-"  # Log to stdout/err
     config.errorlog = "-"
     config.keep_alive_max_requests = 2
 
     async with trio.open_nursery() as nursery:
         shutdown = trio.Event()
+
         async def serve():
             await hypercorn.trio.serve(app, config, shutdown_trigger=shutdown.wait)
         nursery.start_soon(serve)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ isolated_build = true
 [testenv]
 deps =
     py37: mock
+    httpx
     hypothesis
     pytest
     pytest-asyncio


### PR DESCRIPTION
Adds a test that demonstrates bad behavior with the previous implementation of `keep_alive_max_requests` in HTTP/1.1 and fixes the issue.

Previously this would die with
`httpx.ReadError: socket connection broken: [Errno 54] Connection reset by peer`

after the third request