### PR TITLE
Don't completely crash server on uncaught exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ hypercorn = "hypercorn.__main__:main"
 [tool.poetry.extras]
 docs = ["pydata_sphinx_theme", "sphinxcontrib_mermaid"]
 h3 = ["aioquic"]
-trio = ["exceptiongroup", "trio"]
+trio = ["trio"]
 uvloop = ["uvloop"]
 
 [tool.black]

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -13,6 +13,9 @@ from ..protocol import ProtocolWrapper
 from ..typing import AppWrapper
 from ..utils import parse_socket_addr
 
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
+
 MAX_RECV = 2**16
 
 

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from math import inf
 from typing import Any, Generator, Optional
 
@@ -50,12 +49,12 @@ class TCPServer:
             socket = self.stream.socket
             ssl = False
 
-        def log_handler(e: Exception):
+        def log_handler(e: Exception) -> None:
             if self.config.log.error_logger is not None:
                 self.config.log.error_logger.exception("Internal hypercorn error")
 
         try:
-            with exceptiongroup.catch({Exception: log_handler}):
+            with exceptiongroup.catch({Exception: log_handler}):  # type: ignore
                 client = parse_socket_addr(socket.family, socket.getpeername())
                 server = parse_socket_addr(socket.family, socket.getsockname())
 

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -68,8 +68,8 @@ class TCPServer:
                 await self.protocol.initiate()
                 await self._start_idle()
                 await self._read_data()
-        except OSError:
-            pass
+        except (OSError, BaseExceptionGroup):
+            await self.config.log.exception("Internal hypercorn error")
         finally:
             await self._close()
 

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -54,7 +54,9 @@ class TCPServer:
                 self.config.log.error_logger.exception("Internal hypercorn error", exc_info=e)
 
         try:
-            with exceptiongroup.catch({Exception: log_handler}):  # type: ignore
+            with exceptiongroup.catch(
+                {OSError: lambda e: None, Exception: log_handler}  # type: ignore
+            ):
                 client = parse_socket_addr(socket.family, socket.getpeername())
                 server = parse_socket_addr(socket.family, socket.getsockname())
 

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -51,7 +51,7 @@ class TCPServer:
 
         def log_handler(e: Exception) -> None:
             if self.config.log.error_logger is not None:
-                self.config.log.error_logger.exception("Internal hypercorn error")
+                self.config.log.error_logger.exception("Internal hypercorn error", exc_info=e)
 
         try:
             with exceptiongroup.catch({Exception: log_handler}):  # type: ignore

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -15,9 +15,6 @@ from ..protocol import ProtocolWrapper
 from ..typing import AppWrapper
 from ..utils import parse_socket_addr
 
-if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup
-
 MAX_RECV = 2**16
 
 


### PR DESCRIPTION
Partial mitigation for https://github.com/pgjones/hypercorn/issues/225

This doesn't fix the underlying `AttributeError: 'WSStream' object has no attribute 'connection'` but it does allow the server to stay up and healthy when it encounters this bug.