### PR TITLE
Support aioquic 1.x and update README.rst regarding HTTP/3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,7 @@ Gunicorn. Hypercorn supports HTTP/1, HTTP/2, WebSockets (over HTTP/1
 and HTTP/2), ASGI, and WSGI specifications. Hypercorn can utilise
 asyncio, uvloop, or trio worker types.
 
-Hypercorn can optionally serve the current draft of the HTTP/3
-specification using the `aioquic
+Hypercorn can optionally support HTTP/3 using the `aioquic
 <https://github.com/aiortc/aioquic/>`_ library. To enable this install
 the ``h3`` optional extra, ``pip install hypercorn[h3]`` and then
 choose a quic binding e.g. ``hypercorn --quic-bind localhost:4433

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ documentation = "https://hypercorn.readthedocs.io"
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-aioquic = { version = ">= 0.9.0, < 1.0", optional = true }
+aioquic = { version = ">= 0.9.0, < 2.0", optional = true }
 exceptiongroup = { version = ">= 1.1.0", python = "<3.11" }
 h11 = "*"
 h2 = ">=3.1.0"


### PR DESCRIPTION
No code changes are required to use `aioquic` 1.x. As `aioquic` now uses semantic versioning, allow any version less than 2.0. This allows users to benefit from improvements and security fixes which have landed in the 1.x releases, see:

https://aioquic.readthedocs.io/en/stable/changelog.html