### PR TITLE
[docs] Fix building the API reference.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath('../src'))
 
 from importlib.metadata import version as meta_version
 


### PR DESCRIPTION
Why? docs are great

I noticed the docs have an empty API reference page; a quick check locally seems to confirm the problem is that the usual sphinx `sys.path` adjustments predate moving the source into `src/hypercorn`; this PR fixes the path accordingly.

(Happy to _remove_ the `../` entry too, but wasn't sure if something else has quietly grown a dep on that in the docs.)