### PR TITLE
set end_stream=True when sending trailers

### DIFF
--- a/src/hypercorn/protocol/h2.py
+++ b/src/hypercorn/protocol/h2.py
@@ -217,7 +217,10 @@ class H2Protocol:
                 await self.has_data.set()
                 await self.stream_buffers[event.stream_id].drain()
             elif isinstance(event, Trailers):
-                self.connection.send_headers(event.stream_id, event.headers)
+                self.priority.unblock(event.stream_id)
+                await self.has_data.set()
+                await self.stream_buffers[event.stream_id].drain()
+                self.connection.send_headers(event.stream_id, event.headers, end_stream=True)
                 await self._flush()
             elif isinstance(event, StreamClosed):
                 await self._close_stream(event.stream_id)


### PR DESCRIPTION
Explanation in https://github.com/pgjones/hypercorn/issues/254

If the approach is approved (I assume details might be wrong) then I'll gladly add some tests to prevent regressions.

I ran tox and only mypy seems to be failing.

I tested manually with some grpc clients and they show the response properly (though I only tested unary calls, as my grpc-asgi server doesn't handle streaming responses yet).

Not sure how to handle it with more_trailers=True, but I don't understand how it's supposed to work in general since http2 requires END_STREAM being set for trailers frame (unless more_trailers might mean more-in-the-same-frame?).