### PR TITLE
Make handling of 'root_path' in dispatcher middleware adhere to ASGI spec

### DIFF
--- a/src/hypercorn/middleware/dispatcher.py
+++ b/src/hypercorn/middleware/dispatcher.py
@@ -18,9 +18,10 @@ class _DispatcherMiddleware:
         if scope["type"] == "lifespan":
             await self._handle_lifespan(scope, receive, send)
         else:
+            relative_path = scope["path"][len(scope["root_path"]):]
             for path, app in self.mounts.items():
-                if scope["path"].startswith(path):
-                    scope["path"] = scope["path"][len(path) :] or "/"
+                if relative_path.startswith(path):
+                    scope["root_path"] += path
                     return await app(scope, receive, send)
             await send(
                 {


### PR DESCRIPTION
Before this change, the dispatcher middleware didn't do anything with 'root_path'. It did, however, modify 'path'.

The problem with this behavior, is that the child ASGI app has no way to determine what its prefix it. And if it can't determine its prefix, it doesn't know how to construct URLs.

The ASGI spec isn't super clear on the expected behavior. However, some resources to review are:

* https://asgi.readthedocs.io/en/latest/specs/www.html#wsgi-compatibility
* https://github.com/encode/starlette/pull/2400
* https://github.com/django/asgiref/issues/229

Based on the above, I believe that the correct behavior is that "root_path" should be updated by the dispatcher middleware but that "path" should not be modified.

In addition to the above change, I also updated the tests. And I also added a new test case where the dispatcher middleware is nested inside of itself.