### PR TITLE
Add write_timeout option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 poetry.lock
 .idea/
 .DS_Store
+.vscode/settings.json

--- a/docs/how_to_guides/configuring.rst
+++ b/docs/how_to_guides/configuring.rst
@@ -105,6 +105,8 @@ graceful_timeout           ``--graceful-timeout``        Time to wait after SIGT
                                                          for any remaining requests (tasks) to
 read_timeout               ``--read-timeout``            Seconds to wait before timing out reads         No timeout.
                                                          on TCP sockets.
+write_timeout               ``--write-timeout``          Seconds to wait before timing out writes        No timeout.
+                                                         on TCP sockets.
 group                      ``-g``, ``--group``           Group to own any unix sockets.
 h11_max_incomplete_size    N/A                           The max HTTP/1.1 request line + headers         16KiB
                                                          size in bytes.

--- a/src/hypercorn/__main__.py
+++ b/src/hypercorn/__main__.py
@@ -90,6 +90,12 @@ def main(sys_args: Optional[List[str]] = None) -> int:
         type=int,
     )
     parser.add_argument(
+        "--write-timeout",
+        help="""Seconds to wait before timing out response writes on TCP sockets""",
+        default=sentinel,
+        type=int,
+    )
+    parser.add_argument(
         "--max-requests",
         help="""Maximum number of requests a worker will process before restarting""",
         default=sentinel,
@@ -255,6 +261,8 @@ def main(sys_args: Optional[List[str]] = None) -> int:
         config.graceful_timeout = args.graceful_timeout
     if args.read_timeout is not sentinel:
         config.read_timeout = args.read_timeout
+    if args.write_timeout is not sentinel:
+        config.write_timeout = args.write_timeout
     if args.group is not sentinel:
         config.group = args.group
     if args.keep_alive is not sentinel:

--- a/src/hypercorn/asyncio/tcp_server.py
+++ b/src/hypercorn/asyncio/tcp_server.py
@@ -84,19 +84,16 @@ class TCPServer:
                     while offset < len(data):
                         chunk = data[offset:offset + MAX_SEND]
                         self.writer.write(chunk)
-                        try:
-                            await asyncio.wait_for(
-                                self.writer.drain(),
-                                timeout=self.config.write_timeout
-                            )
-                        except asyncio.TimeoutError:
-                            raise
+                        await asyncio.wait_for(
+                            self.writer.drain(),
+                            timeout=self.config.write_timeout
+                        )
                         offset += len(chunk)
                 except (
                     ConnectionError,
                     RuntimeError,
                     asyncio.TimeoutError,
-                ) as e:
+                ):
                     await self.protocol.handle(Closed())
         elif isinstance(event, Closed):
             await self._close()

--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -75,6 +75,7 @@ class Config:
     errorlog: Union[logging.Logger, str, None] = "-"
     graceful_timeout: float = 3 * SECONDS
     read_timeout: Optional[int] = None
+    write_timeout: Optional[int] = None
     group: Optional[int] = None
     h11_max_incomplete_size = 16 * 1024 * BYTES
     h11_pass_raw_headers = False

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -101,8 +101,7 @@ class TCPServer:
                     trio.BrokenResourceError,
                     trio.ClosedResourceError,
                     trio.TooSlowError,
-                ) as e:
-                    print(f"Protocol send error: {e}")
+                ):
                     await self.protocol.handle(Closed())
         elif isinstance(event, Closed):
             await self._close()


### PR DESCRIPTION
This adds a write_timeout option, similar to existing option read_timeout, but for timeout while writing responses.

The usecase is to detect and fail early if a client doesn't promptly read & ack response packets. (Either regular client, or intentionally malicious client doing a "slow read" attack).

In order to implement it properly and have identical semantics to read_timeout, I needed to refactor to switch sending to be chunk-based.

I'm new to this codebase, feedback would be great!

The other things we could do:
- just be ok with write_timeout not being chunk-based the same way read_timeout is, and have it be for the entire response (though I'm worried this wouldn't be as reliable detection of slow clients)
- make MAX_SEND configurable as well?
- if write_timeout not set, use the existing code, otherwise if write_timeout is set we do the chunk-based.