### PR TITLE
fix connection state leak

### DIFF
--- a/src/hypercorn/asyncio/tcp_server.py
+++ b/src/hypercorn/asyncio/tcp_server.py
@@ -60,7 +60,7 @@ class TCPServer:
                     self.config,
                     self.context,
                     task_group,
-                    ConnectionState(self.state.copy()),
+                    ConnectionState(self.state),
                     ssl,
                     client,
                     server,

--- a/src/hypercorn/protocol/http_stream.py
+++ b/src/hypercorn/protocol/http_stream.py
@@ -97,7 +97,7 @@ class HTTPStream:
                 "headers": event.headers,
                 "client": self.client,
                 "server": self.server,
-                "state": event.state,
+                "state": event.state.copy(),
                 "extensions": {},
             }
 

--- a/src/hypercorn/protocol/ws_stream.py
+++ b/src/hypercorn/protocol/ws_stream.py
@@ -219,7 +219,7 @@ class WSStream:
                 "headers": event.headers,
                 "client": self.client,
                 "server": self.server,
-                "state": event.state,
+                "state": event.state.copy(),
                 "subprotocols": self.handshake.subprotocols or [],
                 "extensions": {"websocket.http.response": {}},
             }

--- a/src/hypercorn/trio/tcp_server.py
+++ b/src/hypercorn/trio/tcp_server.py
@@ -63,7 +63,7 @@ class TCPServer:
                     self.config,
                     self.context,
                     task_group,
-                    ConnectionState(self.state.copy()),
+                    ConnectionState(self.state),
                     ssl,
                     client,
                     server,


### PR DESCRIPTION
Fix https://github.com/pgjones/hypercorn/issues/274 by ensuring state is copied for each request.

<hr>
While I could verify that the fix works for WS as well locally, I'm not sure how to properly test it within the test suite. Would be glad for any pointers :)