### PR TITLE
Migrate pyproject to use newer syntax for poetry groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ typing_extensions = { version = "*", python = "<3.11" }
 uvloop = { version = ">=0.18", markers = "platform_system != 'Windows'", optional = true }
 wsproto = ">=0.14.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 httpx = "*"
 hypothesis = "*"
 mock = "*"


### PR DESCRIPTION
# PR Summary
This small PR resolves the following warning:
```
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
```