### PR TITLE
fix failing CI, update python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {name: '3.14', python: '3.14', tox: py314}
+          - {name: '3.13', python: '3.13', tox: py313}
           - {name: '3.12', python: '3.12', tox: py312}
           - {name: '3.11', python: '3.11', tox: py311}
           - {name: '3.10', python: '3.10', tox: py310}
           - {name: '3.9', python: '3.9', tox: py39}
-          - {name: '3.8', python: '3.8', tox: py38}
-          - {name: 'format', python: '3.12', tox: format}
-          - {name: 'mypy', python: '3.12', tox: mypy}
-          - {name: 'pep8', python: '3.12', tox: pep8}
-          - {name: 'package', python: '3.12', tox: package}
+          - {name: 'format', python: '3.13', tox: format}
+          - {name: 'mypy', python: '3.13', tox: mypy}
+          - {name: 'pep8', python: '3.13', tox: pep8}
+          - {name: 'package', python: '3.13', tox: package}
 
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +57,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: update pip
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - run: |
           pip install poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,12 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
@@ -26,7 +27,7 @@ repository = "https://github.com/pgjones/hypercorn/"
 documentation = "https://hypercorn.readthedocs.io"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 aioquic = { version = ">= 0.9.0, < 1.0", optional = true }
 exceptiongroup = { version = ">= 1.1.0", python = "<3.11" }
 h11 = "*"
@@ -41,7 +42,7 @@ typing_extensions = { version = "*", python = "<3.11" }
 uvloop = { version = ">=0.18", markers = "platform_system != 'Windows'", optional = true }
 wsproto = ">=0.14.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 httpx = "*"
 hypothesis = "*"
 mock = "*"
@@ -61,7 +62,7 @@ uvloop = ["uvloop"]
 
 [tool.black]
 line-length = 100
-target-version = ["py38"]
+target-version = ["py39"]
 
 [tool.isort]
 combine_as_imports = true
@@ -104,6 +105,7 @@ warn_return_any = true
 
 [tool.pytest.ini_options]
 addopts = "--no-cov-on-fail --showlocals --strict-markers"
+asyncio_default_fixture_loop_scope = "function"  # silence deprecationwarning
 asyncio_mode = "strict"
 testpaths = ["tests"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 ignore = E203, E252, FI58, W503, W504
 max_line_length = 100
-min_version = 3.8
+min_version = 3.9
 require_code = True

--- a/src/hypercorn/asyncio/run.py
+++ b/src/hypercorn/asyncio/run.py
@@ -102,8 +102,6 @@ async def worker_serve(
     server_tasks: Set[asyncio.Task] = set()
 
     async def _server_callback(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        nonlocal server_tasks
-
         task = asyncio.current_task(loop)
         server_tasks.add(task)
         task.add_done_callback(server_tasks.discard)

--- a/src/hypercorn/logging.py
+++ b/src/hypercorn/logging.py
@@ -34,7 +34,7 @@ def _create_logger(
     if target:
         logger = logging.getLogger(name)
         logger.handlers = [
-            logging.StreamHandler(sys_default) if target == "-" else logging.FileHandler(target)  # type: ignore # noqa: E501
+            logging.StreamHandler(sys_default) if target == "-" else logging.FileHandler(target)
         ]
         logger.propagate = propagate
         formatter = logging.Formatter(

--- a/src/hypercorn/protocol/__init__.py
+++ b/src/hypercorn/protocol/__init__.py
@@ -91,6 +91,10 @@ class ProtocolWrapper:
                 self.server,
                 self.send,
             )
-            await self.protocol.initiate(error.headers, error.settings)
+            # H2Connection only accepts bytes, not str, but it passes the value to
+            # base64.urlsafe_b64encode that also handles ASCII strings.
+            # But H2CProtocolRequiredError intentionally decodes bytes in __init__,
+            # which should maybe be remedied.
+            await self.protocol.initiate(error.headers, error.settings)  # type: ignore[arg-type]
             if error.data != b"":
                 return await self.protocol.handle(RawData(data=error.data))

--- a/src/hypercorn/run.py
+++ b/src/hypercorn/run.py
@@ -56,7 +56,7 @@ def run(config: Config) -> int:
         shutdown_event = ctx.Event()
 
         def shutdown(*args: Any) -> None:
-            nonlocal active, shutdown_event
+            nonlocal active
             shutdown_event.set()
             active = False
 

--- a/src/hypercorn/trio/__init__.py
+++ b/src/hypercorn/trio/__init__.py
@@ -16,7 +16,7 @@ async def serve(
     config: Config,
     *,
     shutdown_trigger: Optional[Callable[..., Awaitable[None]]] = None,
-    task_status: trio.TaskStatus = trio.TASK_STATUS_IGNORED,
+    task_status: trio.TaskStatus[list[str]] = trio.TASK_STATUS_IGNORED,
     mode: Optional[Literal["asgi", "wsgi"]] = None,
 ) -> None:
     """Serve an ASGI framework app given the config.

--- a/src/hypercorn/trio/run.py
+++ b/src/hypercorn/trio/run.py
@@ -33,7 +33,7 @@ async def worker_serve(
     *,
     sockets: Optional[Sockets] = None,
     shutdown_trigger: Optional[Callable[..., Awaitable[None]]] = None,
-    task_status: trio.TaskStatus = trio.TASK_STATUS_IGNORED,
+    task_status: trio.TaskStatus[list[str]] = trio.TASK_STATUS_IGNORED,
 ) -> None:
     config.set_statsd_logger_class(StatsdLogger)
 

--- a/src/hypercorn/trio/worker_context.py
+++ b/src/hypercorn/trio/worker_context.py
@@ -11,7 +11,7 @@ from ..typing import Event, SingleTask, TaskGroup
 def _cancel_wrapper(func: Callable[[], Awaitable[None]]) -> Callable[[], Awaitable[None]]:
     @wraps(func)
     async def wrapper(
-        task_status: trio.TaskStatus = trio.TASK_STATUS_IGNORED,
+        task_status: trio.TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
     ) -> None:
         cancel_scope = trio.CancelScope()
         task_status.started(cancel_scope)

--- a/src/hypercorn/utils.py
+++ b/src/hypercorn/utils.py
@@ -18,6 +18,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Tuple,
     TYPE_CHECKING,
 )
@@ -74,7 +75,7 @@ def build_and_validate_headers(headers: Iterable[Tuple[bytes, bytes]]) -> List[T
     return validated_headers
 
 
-def filter_pseudo_headers(headers: List[Tuple[bytes, bytes]]) -> List[Tuple[bytes, bytes]]:
+def filter_pseudo_headers(headers: Sequence[Tuple[bytes, bytes]]) -> List[Tuple[bytes, bytes]]:
     filtered_headers: List[Tuple[bytes, bytes]] = [(b"host", b"")]  # Placeholder
     authority = None
     host = b""

--- a/tests/asyncio/test_sanity.py
+++ b/tests/asyncio/test_sanity.py
@@ -224,11 +224,13 @@ async def test_http2_websocket() -> None:
     h2_client.send_data(stream_id, client.send(wsproto.events.BytesMessage(data=SANITY_BODY)))
     await server.reader.send(h2_client.data_to_send())  # type: ignore
     events = h2_client.receive_data(await server.writer.receive())  # type: ignore
+    assert isinstance(events[0], h2.events.DataReceived)
     client.receive_data(events[0].data)
     assert list(client.events()) == [wsproto.events.TextMessage(data="Hello & Goodbye")]
     h2_client.send_data(stream_id, client.send(wsproto.events.CloseConnection(code=1000)))
     await server.reader.send(h2_client.data_to_send())  # type: ignore
     events = h2_client.receive_data(await server.writer.receive())  # type: ignore
+    assert isinstance(events[0], h2.events.DataReceived)
     client.receive_data(events[0].data)
     assert list(client.events()) == [wsproto.events.CloseConnection(code=1000, reason="")]
     h2_client.close_connection()

--- a/tests/middleware/test_dispatcher.py
+++ b/tests/middleware/test_dispatcher.py
@@ -33,7 +33,6 @@ async def test_dispatcher_middleware(http_scope: HTTPScope) -> None:
     sent_events = []
 
     async def send(message: dict) -> None:
-        nonlocal sent_events
         sent_events.append(message)
 
     await app({**http_scope, **{"path": "/api/x/b"}}, None, send)  # type: ignore
@@ -66,7 +65,6 @@ async def test_asyncio_dispatcher_lifespan() -> None:
     sent_events = []
 
     async def send(message: dict) -> None:
-        nonlocal sent_events
         sent_events.append(message)
 
     async def receive() -> dict:
@@ -83,7 +81,6 @@ async def test_trio_dispatcher_lifespan() -> None:
     sent_events = []
 
     async def send(message: dict) -> None:
-        nonlocal sent_events
         sent_events.append(message)
 
     async def receive() -> dict:

--- a/tests/middleware/test_http_to_https.py
+++ b/tests/middleware/test_http_to_https.py
@@ -14,7 +14,6 @@ async def test_http_to_https_redirect_middleware_http(raw_path: bytes) -> None:
     sent_events = []
 
     async def send(message: dict) -> None:
-        nonlocal sent_events
         sent_events.append(message)
 
     scope: HTTPScope = {
@@ -53,7 +52,6 @@ async def test_http_to_https_redirect_middleware_websocket(raw_path: bytes) -> N
     sent_events = []
 
     async def send(message: dict) -> None:
-        nonlocal sent_events
         sent_events.append(message)
 
     scope: WebsocketScope = {
@@ -90,7 +88,6 @@ async def test_http_to_https_redirect_middleware_websocket_http2() -> None:
     sent_events = []
 
     async def send(message: dict) -> None:
-        nonlocal sent_events
         sent_events.append(message)
 
     scope: WebsocketScope = {
@@ -127,7 +124,6 @@ async def test_http_to_https_redirect_middleware_websocket_no_rejection() -> Non
     sent_events = []
 
     async def send(message: dict) -> None:
-        nonlocal sent_events
         sent_events.append(message)
 
     scope: WebsocketScope = {

--- a/tests/protocol/test_h11.py
+++ b/tests/protocol/test_h11.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import call, Mock
+from unittest.mock import AsyncMock, call, Mock
 
 import h11
 import pytest
@@ -17,13 +17,6 @@ from hypercorn.protocol.events import Body, Data, EndBody, EndData, Request, Res
 from hypercorn.protocol.h11 import H2CProtocolRequiredError, H2ProtocolAssumedError, H11Protocol
 from hypercorn.protocol.http_stream import HTTPStream
 from hypercorn.typing import ConnectionState, Event as IOEvent
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # Python < 3.8
-    from mock import AsyncMock  # type: ignore
-
 
 BASIC_HEADERS = [("Host", "hypercorn"), ("Connection", "close")]
 

--- a/tests/protocol/test_h2.py
+++ b/tests/protocol/test_h2.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import call, Mock
+from unittest.mock import AsyncMock, call, Mock
 
 import pytest
 from h2.connection import H2Connection
@@ -12,12 +12,6 @@ from hypercorn.config import Config
 from hypercorn.events import Closed, RawData
 from hypercorn.protocol.h2 import BUFFER_HIGH_WATER, BufferCompleteError, H2Protocol, StreamBuffer
 from hypercorn.typing import ConnectionState
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # Python < 3.8
-    from mock import AsyncMock  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, cast
-from unittest.mock import call
+from unittest.mock import AsyncMock, call
 
 import pytest
 import pytest_asyncio
@@ -27,12 +27,6 @@ from hypercorn.typing import (
     HTTPScope,
 )
 from hypercorn.utils import UnexpectedMessageError
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # Python < 3.8
-    from mock import AsyncMock  # type: ignore
 
 
 @pytest_asyncio.fixture(name="stream")  # type: ignore[misc]

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, cast, List, Tuple
-from unittest.mock import call, Mock
+from unittest.mock import AsyncMock, call, Mock
 
 import pytest
 import pytest_asyncio
@@ -29,12 +29,6 @@ from hypercorn.typing import (
     WebsocketSendEvent,
 )
 from hypercorn.utils import UnexpectedMessageError
-
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # Python < 3.8
-    from mock import AsyncMock  # type: ignore
 
 
 def test_buffer() -> None:

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -47,7 +47,6 @@ async def test_wsgi_trio() -> None:
     messages = []
 
     async def _send(message: ASGISendEvent) -> None:
-        nonlocal messages
         messages.append(message)
 
     await app(scope, receive_channel.receive, _send, trio.to_thread.run_sync, trio.from_thread.run)
@@ -69,7 +68,6 @@ async def _run_app(app: WSGIWrapper, scope: HTTPScope, body: bytes = b"") -> Lis
     messages = []
 
     async def _send(message: ASGISendEvent) -> None:
-        nonlocal messages
         messages.append(message)
 
     event_loop = asyncio.get_running_loop()

--- a/tests/trio/test_keep_alive.py
+++ b/tests/trio/test_keep_alive.py
@@ -81,13 +81,10 @@ async def test_http1_keep_alive_during(
     client_stream: ClientStream,
 ) -> None:
     client = h11.Connection(h11.CLIENT)
-    # client.send(h11.Request) and client.send(h11.EndOfMessage) only returns bytes.
-    # Fixed on master/ in the h11 repo, once released the ignore's can be removed.
-    # See https://github.com/python-hyper/h11/issues/175
-    await client_stream.send_all(client.send(REQUEST))  # type: ignore[arg-type]
+    await client_stream.send_all(client.send(REQUEST))
     await trio.sleep(2 * KEEP_ALIVE_TIMEOUT)
     # Key is that this doesn't error
-    await client_stream.send_all(client.send(h11.EndOfMessage()))  # type: ignore[arg-type]
+    await client_stream.send_all(client.send(h11.EndOfMessage()))
 
 
 @pytest.mark.trio
@@ -95,9 +92,9 @@ async def test_http1_keep_alive(
     client_stream: ClientStream,
 ) -> None:
     client = h11.Connection(h11.CLIENT)
-    await client_stream.send_all(client.send(REQUEST))  # type: ignore[arg-type]
+    await client_stream.send_all(client.send(REQUEST))
     await trio.sleep(2 * KEEP_ALIVE_TIMEOUT)
-    await client_stream.send_all(client.send(h11.EndOfMessage()))  # type: ignore[arg-type]
+    await client_stream.send_all(client.send(h11.EndOfMessage()))
     while True:
         event = client.next_event()
         if event == h11.NEED_DATA:
@@ -106,10 +103,10 @@ async def test_http1_keep_alive(
         elif isinstance(event, h11.EndOfMessage):
             break
     client.start_next_cycle()
-    await client_stream.send_all(client.send(REQUEST))  # type: ignore[arg-type]
+    await client_stream.send_all(client.send(REQUEST))
     await trio.sleep(2 * KEEP_ALIVE_TIMEOUT)
     # Key is that this doesn't error
-    await client_stream.send_all(client.send(h11.EndOfMessage()))  # type: ignore[arg-type]
+    await client_stream.send_all(client.send(h11.EndOfMessage()))
 
 
 @pytest.mark.trio

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = docs,format,mypy,py38,py39,py310,py311,py312,package,pep8
+envlist = docs,format,mypy,py39,py310,py311,py312,py313,py314,package,pep8
 minversion = 3.3
 isolated_build = true
 
 [testenv]
 deps =
-    py37: mock
     httpx
     hypothesis
     pytest
@@ -16,7 +15,7 @@ deps =
 commands = pytest --cov=hypercorn {posargs}
 
 [testenv:docs]
-basepython = python3.12
+basepython = python3.13
 deps =
     pydata-sphinx-theme
     sphinx
@@ -27,7 +26,7 @@ commands =
     sphinx-build -W --keep-going -b html -d {envtmpdir}/doctrees docs/ docs/_build/html/
 
 [testenv:format]
-basepython = python3.12
+basepython = python3.13
 deps =
     black
     isort
@@ -36,7 +35,7 @@ commands =
     isort --check --diff src/hypercorn tests
 
 [testenv:pep8]
-basepython = python3.12
+basepython = python3.13
 deps =
     flake8
     pep8-naming
@@ -45,7 +44,7 @@ deps =
 commands = flake8 src/hypercorn/ tests/
 
 [testenv:mypy]
-basepython = python3.12
+basepython = python3.13
 deps =
     mypy
     pytest
@@ -54,7 +53,7 @@ commands =
     mypy src/hypercorn/ tests/
 
 [testenv:package]
-basepython = python3.12
+basepython = python3.13
 deps =
     poetry
     twine


### PR DESCRIPTION
drop 3.8 testing+support
remove some 3.7 remnants
add 3.13 and 3.14 testing+support
silence pytest-asyncio deprecationwarning
fix typing errors
fix pep8 errors
fix poetry warning

incorporates #271 and #272 


this code base would also benefit from running flake8-upgrade (or similar) and replace all imports from `typing` that can be replaced with standard objects (e.g. `List` -> `list`) but I thought this PR was big enough already.