### PR TITLE
h3: Remove streams on StreamClosed

### DIFF
--- a/src/hypercorn/protocol/h3.py
+++ b/src/hypercorn/protocol/h3.py
@@ -86,7 +86,8 @@ class H3Protocol:
             self.connection.send_headers(event.stream_id, event.headers)
             await self.send()
         elif isinstance(event, StreamClosed):
-            pass  # ??
+            # Remove a stream when it's closed to avoid memory leaks
+            self.streams.pop(event.stream_id, None)
         elif isinstance(event, Request):
             await self._create_server_push(event.stream_id, event.raw_path, event.headers)
 


### PR DESCRIPTION
Hi! I was playing around with HTTP3 in Hypercorn and noticed significant memory leaks during long-lived connections.

After some investigation, I discovered that Hypercorn doesn't properly remove finished streams from the `H3Protocol.streams` dict. This leads to unbounded memory growth over time.

This PR fixes the issue. Interestingly, the solution is just one line: the `StreamClosed` event was already being handled in the H3 protocol, but the handler didn't actually remove the stream.

However, there is another memory leak, this time in the aioquic library itself, which I addresses in this PR - https://github.com/aiortc/aioquic/pull/590. Once (and if) that fix is merged, Hypercorn should bump its aioquic dependency to ensure that both memory leaks are fully resolved.