### PR TITLE
Update graceful_timeout documentation with default value of 3s

### DIFF
--- a/docs/how_to_guides/configuring.rst
+++ b/docs/how_to_guides/configuring.rst
@@ -101,7 +101,7 @@ dogstatsd_tags             N/A                           DogStatsd format tag, s
                                                          :ref:`using_statsd`.
 errorlog                   ``--error-logfile``           The target location for the error log,
                            ``--log-file``                use `-` for stderr.
-graceful_timeout           ``--graceful-timeout``        Time to wait after SIGTERM or Ctrl-C
+graceful_timeout           ``--graceful-timeout``        Time to wait after SIGTERM or Ctrl-C            3s
                                                          for any remaining requests (tasks) to
 read_timeout               ``--read-timeout``            Seconds to wait before timing out reads         No timeout.
                                                          on TCP sockets.


### PR DESCRIPTION
Added default value for graceful_timeout in documentation.

As seen here https://github.com/pgjones/hypercorn/blob/main/src/hypercorn/config.py#L76