### PR TITLE
Bugfix handle already-closed on DataReceived

### DIFF
--- a/src/hypercorn/protocol/h2.py
+++ b/src/hypercorn/protocol/h2.py
@@ -256,12 +256,16 @@ class H2Protocol:
                 if self.keep_alive_requests > self.config.keep_alive_max_requests:
                     self.connection.close_connection()
             elif isinstance(event, h2.events.DataReceived):
-                await self.streams[event.stream_id].handle(
-                    Body(stream_id=event.stream_id, data=event.data)
-                )
-                self.connection.acknowledge_received_data(
-                    event.flow_controlled_length, event.stream_id
-                )
+                try:
+                    await self.streams[event.stream_id].handle(
+                        Body(stream_id=event.stream_id, data=event.data)
+                    )
+                    self.connection.acknowledge_received_data(
+                        event.flow_controlled_length, event.stream_id
+                    )
+                except KeyError:
+                    # Data received while already closed, nothing to do.
+                    pass
             elif isinstance(event, h2.events.StreamEnded):
                 try:
                     await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))


### PR DESCRIPTION
This solves https://github.com/pgjones/hypercorn/issues/329 (and the late comment in https://github.com/pgjones/hypercorn/issues/197#issuecomment-2388694420 )

Similar to https://github.com/pgjones/hypercorn/pull/199 , but this time data is _received_ on a closed stream.

See https://github.com/pgjones/hypercorn/issues/329 for a reproducible environment.