### PR TITLE
Handle TimeoutError when waiting for the writer to close

### DIFF
--- a/src/hypercorn/asyncio/tcp_server.py
+++ b/src/hypercorn/asyncio/tcp_server.py
@@ -124,7 +124,12 @@ class TCPServer:
             ConnectionResetError,
             RuntimeError,
             asyncio.CancelledError,
-        ):
+            TimeoutError,
+        ) as exc:
+            if isinstance(exc, TimeoutError):
+                transport = getattr(self.writer, "transport", None)
+                if transport is not None:
+                    transport.abort()
             pass  # Already closed
         finally:
             await self.idle_task.stop()


### PR DESCRIPTION
This is a PR to fix #202. As the issue indicates, the error is:

```
  File "[...]/hypercorn/asyncio/tcp_server.py", line 119, in _close
    await self.writer.wait_closed()
  File "/usr/lib/python3.12/asyncio/streams.py", line 364, in wait_closed
    await self._protocol._get_close_waiter(self)
TimeoutError: SSL shutdown timed out
```

This happens because `asyncio` sets a timeout on the close. If the client is idle, then when the timeout period is reached it raises the error above. This patch fixes that by adding `TimeoutError` to the list of exceptions caught when calling `self.writer.wait_closed`; it also tries to abort the transport to clean up resources. I tested with `asyncio` and with `uvloop`, where the transport classes are `asyncio.sslproto._SSLProtocolTransport` and `uvloop.loop._SSLProtocolTransport` respectively.

I am submitting this PR as an individual contributor under the existing Hypercorn MIT license.
