### PR TITLE
chore: remove unused mock dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ uvloop = ["uvloop"]
 dev = [
     "httpx",
     "hypothesis",
-    "mock",
     "pytest",
     "pytest-asyncio",
     "pytest-trio",


### PR DESCRIPTION
The tests use unittest.mock from the standard library, so the dependency on the mock PyPI backport package is unneeded.