### PR TITLE
fix(tests): add :protocol pseudo-header for Extended CONNECT in WebSo…

### DIFF
--- a/tests/asyncio/test_sanity.py
+++ b/tests/asyncio/test_sanity.py
@@ -203,6 +203,7 @@ async def test_http2_websocket() -> None:
         stream_id,
         [
             (":method", "CONNECT"),
+            (":protocol", "websocket"),
             (":path", "/"),
             (":authority", "hypercorn"),
             (":scheme", "https"),

--- a/tests/trio/test_sanity.py
+++ b/tests/trio/test_sanity.py
@@ -175,6 +175,7 @@ async def test_http2_websocket(nursery: trio._core._run.Nursery) -> None:
         stream_id,
         [
             (":method", "CONNECT"),
+            (":protocol", "websocket"),
             (":path", "/"),
             (":authority", "hypercorn"),
             (":scheme", "https"),


### PR DESCRIPTION
fix(tests): add :protocol pseudo-header for Extended CONNECT in WebSocket tests

h2 >= 4.3.0 enforces RFC 9113 §8.3 which prohibits :scheme and :path
in ordinary CONNECT requests. WebSocket over HTTP/2 requires Extended
CONNECT (RFC 8441) with the :protocol pseudo-header.

Fixes #370 